### PR TITLE
Add lualine theme port

### DIFF
--- a/lua/lualine/themes/nisha.lua
+++ b/lua/lualine/themes/nisha.lua
@@ -1,0 +1,27 @@
+return {
+    normal = {
+        a = {fg = '#191a21', bg = '#ff7d55'},
+        b = {fg = '#191a21', bg = '#99b7c2'},
+        c = {fg = '#efe6dd', bg = '#373a42'},
+    },
+    insert = {
+        a = {fg = '#191a21', bg = '#6bc29a'},
+        b = {fg = '#191a21', bg = '#99b7c2'},
+        c = {fg = '#efe6dd', bg = '#373a42'},
+    },
+    replace = {
+        a = {fg = '#191a21', bg = '#f14358'},
+        b = {fg = '#191a21', bg = '#99b7c2'},
+        c = {fg = '#efe6dd', bg = '#373a42'},
+    },
+    visual = {
+        a = {fg = '#191a21', bg = '#ab797a'},
+        b = {fg = '#191a21', bg = '#99b7c2'},
+        c = {fg = '#efe6dd', bg = '#373a42'},
+    },
+    inactive = {
+        a = {fg = '#efe6dd', bg = '#191a21'},
+        b = {fg = '#191a21', bg = '#99b7c2'},
+        c = {fg = '#efe6dd', bg = '#373a42'},
+    },
+}


### PR DESCRIPTION
This PR adds a port of nisha's airline theme to [lualine](https://github.com/hoob3rt/lualine.nvim), a popular lua-based statusline plugin used by many folks who use neovim (like me!)

It's entirely optional -- if you don't have lualine, and you don't set your lualine theme to `'nisha'`, then nothing will happen. In fact, if you don't have neovim (or neovim 0.5.0 or above), nothing will happen. But if you _do_ have neovim (0.5.0 or above), and you _do_ use lualine, and you _do_ set your lualine theme to `'nisha'`, then you'll get a statusline that at least mostly matches the screenshots shown in this repo.